### PR TITLE
rails 3/ruby 1.9.2 update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'rails',        '3.0.0.beta4'
+  gem 'rails',        '3.0.0'
   gem 'sqlite3-ruby', '1.3.1'
-  gem 'mysql',        '2.8.1'
+  gem 'mysql2'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'http://rubygems.org'
 
 group :development do
-  gem 'rails',        '3.0.0'
-  gem 'sqlite3-ruby', '1.3.1'
+  gem 'rails',        '>=3.0.0'
+  gem 'sqlite3-ruby', '>=1.3.1'
   gem 'mysql2'
 end

--- a/acts_as_versioned.gemspec
+++ b/acts_as_versioned.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_dependency('activerecord', ["~> 3.0.0.beta4"])
+  s.add_dependency('activerecord', [">= 3.0.0"])
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development

--- a/test/fixtures/page.rb
+++ b/test/fixtures/page.rb
@@ -10,9 +10,9 @@ class Page < ActiveRecord::Base
       base.belongs_to :author
       base.belongs_to :revisor, :class_name => 'Author'
     end
-    
+
     def feeling_good?
-      @@feeling_good == true
+      self.class.feeling_good == true
     end
   end
 end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -1,4 +1,4 @@
-require File.join(File.dirname(__FILE__), 'abstract_unit')
+require File.expand_path('../abstract_unit', __FILE__)
 
 if ActiveRecord::Base.connection.supports_migrations? 
   class Thing < ActiveRecord::Base

--- a/test/versioned_test.rb
+++ b/test/versioned_test.rb
@@ -1,6 +1,6 @@
-require File.join(File.dirname(__FILE__), 'abstract_unit')
-require File.join(File.dirname(__FILE__), 'fixtures/page')
-require File.join(File.dirname(__FILE__), 'fixtures/widget')
+require File.expand_path('../abstract_unit', __FILE__)
+require File.expand_path('../fixtures/page', __FILE__)
+require File.expand_path('../fixtures/widget', __FILE__)
 
 class VersionedTest < ActiveSupport::TestCase
   fixtures :pages, :page_versions, :locked_pages, :locked_pages_revisions, :authors, :landmarks, :landmark_versions


### PR DESCRIPTION
the tests ran fine without the mysql gem - i bumped it to mysql2 just because its the rails 3 default and i didnt feel like installing the mysql gem in all my ruby versions. Tested with:
- REE 2010.02
- 1.9.2 P136
- 1.8.7 P174
