### PR TITLE
deleted_in_original_table method

### DIFF
--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -245,6 +245,13 @@ module ActiveRecord #:nodoc:
           def versions_count
             page.version
           end
+
+          # Returns true if record was deleted in original table, else
+          # false.
+          #
+          def deleted_in_original_table
+            not original_class.exists?(self.send original_class.versioned_foreign_key)
+	  end
         end
 
         versioned_class.cattr_accessor :original_class

--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -251,7 +251,7 @@ module ActiveRecord #:nodoc:
           #
           def deleted_in_original_table
             not original_class.exists?(self.send original_class.versioned_foreign_key)
-	  end
+          end
         end
 
         versioned_class.cattr_accessor :original_class

--- a/test/versioned_test.rb
+++ b/test/versioned_test.rb
@@ -367,4 +367,11 @@ class VersionedTest < ActiveSupport::TestCase
     end
     assert ActiveRecord::Base.lock_optimistically
   end
-end
+
+  def test_deleted_in_original_table
+    record = Page::Version.find 1 
+    assert !record.deleted_in_original_table
+    record.page.delete
+    assert record.deleted_in_original_table
+  end
+end 


### PR DESCRIPTION
Dear technoweenie and team, 

We are using acts_as_versioned in our campus management platform of the technical
university of vienna (tiss.tuwien.ac.at) and are very happy with it.

I wrote a small convenience method that given a version model checks if 
the original record has already been deleted. Test is also included in this patch.

Please feel free to pull the patch if you like, it should work out-of-the box.

All the best, 
- Johannes
