### PR TITLE
A Valid Gemspec (Rails 2.3)

### DIFF
--- a/acts_as_versioned.gemspec
+++ b/acts_as_versioned.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["technoweenie"]
   s.date = %q{2009-01-20}
-  s.description = %q{TODO}
+  s.description = "Add simple versioning to ActiveRecord models."
   s.email = %q{technoweenie@bidwell.textdrive.com}
   s.files = ["VERSION.yml", "lib/acts_as_versioned.rb", "test/abstract_unit.rb", "test/database.yml", "test/fixtures", "test/fixtures/authors.yml", "test/fixtures/landmark.rb", "test/fixtures/landmark_versions.yml", "test/fixtures/landmarks.yml", "test/fixtures/locked_pages.yml", "test/fixtures/locked_pages_revisions.yml", "test/fixtures/migrations", "test/fixtures/migrations/1_add_versioned_tables.rb", "test/fixtures/page.rb", "test/fixtures/page_versions.yml", "test/fixtures/pages.yml", "test/fixtures/widget.rb", "test/migration_test.rb", "test/schema.rb", "test/versioned_test.rb"]
   s.has_rdoc = true
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--inline-source", "--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.1}
-  s.summary = %q{TODO}
+  s.summary = "Add simple versioning to ActiveRecord models."
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION


### PR DESCRIPTION
On the Rails 2.3 branch/tag the latest Rubygems complains that `TODO` is not a valid description (pretentious!) and this blows up when cap deploying/bundling.

Also it would be great if this 5.2 version could get pushed to gemcutter ;)

Thanks Rick.
