### PR TITLE
Compatibility with store_multiplied

### DIFF
--- a/lib/acts_as_versioned.rb
+++ b/lib/acts_as_versioned.rb
@@ -331,7 +331,7 @@ module ActiveRecord #:nodoc:
         # Clones a model.  Used when saving a new version or reverting a model's version.
         def clone_versioned_model(orig_model, new_model)
           self.class.versioned_columns.each do |col|
-            new_model[col.name] = orig_model.send(col.name) if orig_model.has_attribute?(col.name)
+            new_model.send(:write_attribute, col.name, orig_model.send(:read_attribute, col.name)) if orig_model.has_attribute?(col.name)
           end
 
           clone_inheritance_column(orig_model, new_model)


### PR DESCRIPTION
In case when field=() and field() methods are being redefined in versioned model, versioning does take it into consideration when reading and does not when writing into revision model. As result when working together with store_multiplied, acts_as_versioned reads integer value stored as micros in database as 900000 returned as 0.9 and stores it into integer field casting it to int as 0. When reverting we get 0 divided by million which equals 0. Better copy raw attributes IMHO.
